### PR TITLE
[1.9.0] Release

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -770,6 +770,57 @@
         }
       }
     },
+    "/private/consent/{userId}/{providerSd}/{consumerSd}/{contractSd}": {
+      "get": {
+        "summary": "Get user privacy notices by contract",
+        "tags": [
+          "Consent"
+        ],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "contractSd",
+            "description": "contract self-description in base64.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "providerSd",
+            "description": "provider self-description in base64.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "consumerSd",
+            "description": "consumer self-description in base64.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "userId",
+            "description": "your internal id inside your app / database for the user.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        }
+      }
+    },
     "/private/credentials/{id}": {
       "put": {
         "summary": "update credentials",
@@ -1298,6 +1349,66 @@
           {
             "name": "id",
             "description": "user id.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        }
+      }
+    },
+    "/private/users/email/{email}": {
+      "get": {
+        "summary": "Get a user by email",
+        "tags": [
+          "Users"
+        ],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "email",
+            "description": "user email.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        }
+      }
+    },
+    "/private/users/userId/{userId}": {
+      "get": {
+        "summary": "Get a user by userId/internalId",
+        "tags": [
+          "Users"
+        ],
+        "security": [
+          {
+            "jwt": []
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "userId",
+            "description": "user internal Id.",
             "in": "path",
             "required": true,
             "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "ptx-dataspace-connector",
-    "version": "1.9.0-beta.2",
+    "version": "1.9.0",
     "description": "Prometheus-X Data Space Connector"
   },
   "paths": {

--- a/generate-swagger.ts
+++ b/generate-swagger.ts
@@ -1,0 +1,17 @@
+import { writeFile } from 'fs';
+// @ts-ignore
+import path from 'path';
+import { Logger } from './src/libs/loggers';
+import { OpenAPIOption } from './openapi-options';
+// @ts-ignore
+import swaggerJSDoc from 'swagger-jsdoc';
+
+const specs = swaggerJSDoc(OpenAPIOption);
+
+writeFile(
+    path.join(__dirname, './docs/swagger.json'),
+    JSON.stringify(specs, null, 2),
+    (err) => {
+        if (err) Logger.error({ message: err.message, location: err.stack });
+    }
+);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
         "lint:fix": "eslint src/**/*.{ts,js} --fix",
         "postinstall": "git init && git config core.hooksPath ./.git-hooks && npm i -g semver",
         "postbuild": "mkdirp dist/src/keys/ && mkdirp dist/docs/ && mkdirp dist/src/public/uploads",
-        "uid": "node uid.js"
+        "uid": "node uid.js",
+        "generate-swagger": "ts-node generate-swagger.ts"
     },
     "keywords": [],
     "author": "",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
         "connect-mongo": "^5.1.0",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
-        "dpcp-library": "https://gitpkg.now.sh/VisionsOfficial/data-processing-chain-protocol/lib?v1.4.1",
+        "dpcp-library": "https://gitpkg.now.sh/Prometheus-X-association/data-processing-chain-protocol/lib?1.4.1",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-session": "^1.17.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ptx-dataspace-connector",
-    "version": "1.9.0-beta.2",
+    "version": "1.9.0",
     "description": "Prometheus-X Data Space Connector",
     "main": "src/index.ts",
     "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^16.3.1
         version: 16.4.5
       dpcp-library:
-        specifier: https://gitpkg.now.sh/VisionsOfficial/data-processing-chain-protocol/lib?v1.4.1
-        version: https://gitpkg.vercel.app/VisionsOfficial/data-processing-chain-protocol/lib?v1.4.1
+        specifier: https://gitpkg.now.sh/Prometheus-X-association/data-processing-chain-protocol/lib?1.4.1
+        version: https://gitpkg.vercel.app/Prometheus-X-association/data-processing-chain-protocol/lib?1.4.1
       express:
         specifier: ^4.18.2
         version: 4.19.2
@@ -1182,8 +1182,8 @@ packages:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
 
-  dpcp-library@https://gitpkg.vercel.app/VisionsOfficial/data-processing-chain-protocol/lib?v1.4.1:
-    resolution: {tarball: https://gitpkg.vercel.app/VisionsOfficial/data-processing-chain-protocol/lib?v1.4.1}
+  dpcp-library@https://gitpkg.vercel.app/Prometheus-X-association/data-processing-chain-protocol/lib?1.4.1:
+    resolution: {tarball: https://gitpkg.vercel.app/Prometheus-X-association/data-processing-chain-protocol/lib?1.4.1}
     version: 1.4.1
 
   eastasianwidth@0.2.0:
@@ -4354,7 +4354,7 @@ snapshots:
 
   dotenv@16.4.5: {}
 
-  dpcp-library@https://gitpkg.vercel.app/VisionsOfficial/data-processing-chain-protocol/lib?v1.4.1:
+  dpcp-library@https://gitpkg.vercel.app/Prometheus-X-association/data-processing-chain-protocol/lib?1.4.1:
     dependencies:
       dotenv: 16.4.5
       express: 4.21.1

--- a/src/controllers/private/v1/consent.private.controller.ts
+++ b/src/controllers/private/v1/consent.private.controller.ts
@@ -12,6 +12,7 @@ import {
     consentServiceDataExchange,
     consentServiceAvailableExchanges,
     consentServiceRevoke,
+    consentServiceGetPrivacyNoticesByContract,
 } from '../../../libs/third-party/consent';
 import { restfulResponse } from '../../../libs/api/RESTfulResponse';
 import { getEndpoint } from '../../../libs/loaders/configuration';
@@ -198,6 +199,30 @@ export const getUserPrivacyNotices = async (
 ) => {
     try {
         const response = await consentServiceGetPrivacyNotices(req);
+        return restfulResponse(res, 200, response);
+    } catch (err) {
+        Logger.error({
+            message: err.message,
+            location: err.stack,
+        });
+        return restfulResponse(
+            res,
+            err?.response?.status,
+            err?.response?.data ?? err.message
+        );
+    }
+};
+
+/**
+ * Get user privacy notices
+ */
+export const getUserPrivacyNoticesByContract = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+) => {
+    try {
+        const response = await consentServiceGetPrivacyNoticesByContract(req);
         return restfulResponse(res, 200, response);
     } catch (err) {
         Logger.error({

--- a/src/controllers/private/v1/user.private.controller.ts
+++ b/src/controllers/private/v1/user.private.controller.ts
@@ -120,6 +120,54 @@ export const getUserById = async (
 };
 
 /**
+ * get a user by email
+ * @param req
+ * @param res
+ * @param next
+ */
+export const getUserByEmail = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+) => {
+    try {
+        const user = await User.findOne({ email: req.params.email }).lean();
+
+        return restfulResponse(res, 200, {
+            ...user,
+            userId: user.internalID,
+        });
+    } catch (err) {
+        next(err);
+    }
+};
+
+/**
+ * get a user by userId
+ * @param req
+ * @param res
+ * @param next
+ */
+export const getUserByUserId = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+) => {
+    try {
+        const user = await User.findOne({
+            internalID: req.params.userId,
+        }).lean();
+
+        return restfulResponse(res, 200, {
+            ...user,
+            userId: user.internalID,
+        });
+    } catch (err) {
+        next(err);
+    }
+};
+
+/**
  * update a user
  * @param req
  * @param res

--- a/src/controllers/public/v1/consent.public.controller.ts
+++ b/src/controllers/public/v1/consent.public.controller.ts
@@ -70,21 +70,30 @@ export const exportConsent = async (req: Request, res: Response) => {
         // Create the data exchange at the provider
         await dataExchange.createDataExchangeToOtherParticipant('consumer');
 
-        for (const service of dataExchange.serviceChain.services) {
-            // Get the infrastructure service information
-            const [participantResponse] = await handle(
-                axios.get(service.participant)
-            );
+        if (
+            dataExchange?.serviceChain &&
+            dataExchange?.serviceChain?.services &&
+            dataExchange?.serviceChain?.services.length > 0
+        ) {
+            for (const service of dataExchange.serviceChain.services) {
+                // Get the infrastructure service information
+                const [participantResponse] = await handle(
+                    axios.get(service.participant)
+                );
 
-            // Find the participant endpoint
-            const participantEndpoint = participantResponse.dataspaceEndpoint;
+                // Find the participant endpoint
+                const participantEndpoint =
+                    participantResponse.dataspaceEndpoint;
 
-            if (
-                participantEndpoint !== dataExchange.consumerEndpoint &&
-                participantEndpoint !== (await getEndpoint())
-            ) {
-                // Sync the data exchange with the infrastructure
-                await dataExchange.syncWithInfrastructure(participantEndpoint);
+                if (
+                    participantEndpoint !== dataExchange.consumerEndpoint &&
+                    participantEndpoint !== (await getEndpoint())
+                ) {
+                    // Sync the data exchange with the infrastructure
+                    await dataExchange.syncWithInfrastructure(
+                        participantEndpoint
+                    );
+                }
             }
         }
 

--- a/src/libs/loaders/nodeSupervisor.ts
+++ b/src/libs/loaders/nodeSupervisor.ts
@@ -150,18 +150,11 @@ export class SupervisorContainer {
                 nextNodeResolver,
             }): Promise<PipelineData> => {
                 Logger.info({
-                    message: `${
-                        process.env.PORT
-                    } - PipelineProcessor pre callback invoked:
-                      - chainId: ${chainId}
-                      - nextTargetId: ${nextTargetId}
-                      - nextNodeResolver: ${nextNodeResolver}
-                      - Connector: ${this.uid}
-                      - Target: ${targetId}
-                      - MetaData: ${JSON.stringify(meta?.configuration)}
-                      - Data size: ${JSON.stringify(data)?.length} bytes
-                      - Received DATA: ${JSON.stringify(data ?? undefined)}
-          `,
+                    message: `PipelineProcessor pre callback invoked - Connector: ${
+                        this.uid
+                    }, Target: ${targetId}, Data size: ${
+                        JSON.stringify(data).length
+                    } bytes`,
                 });
                 return await nodePreCallbackService({
                     targetId,
@@ -177,9 +170,9 @@ export class SupervisorContainer {
 
         await Ext.Resolver.setResolverCallbacks({
             paths: {
-                pre: '/node/communicate/pre',
-                setup: '/node/communicate/setup',
-                run: '/node/communicate/run',
+                pre: '/service-chain/node/pre',
+                setup: '/service-chain/node/setup',
+                run: '/service-chain/node/run',
             },
             hostResolver: (targetId: string, meta?: PipelineMeta) => {
                 Logger.info({
@@ -202,7 +195,7 @@ export class SupervisorContainer {
 
         await Ext.Reporting.setMonitoringCallbacks({
             paths: {
-                notify: '/node/communicate/notify',
+                notify: '/service-chain/node/notify',
             },
         });
 

--- a/src/libs/third-party/consent.ts
+++ b/src/libs/third-party/consent.ts
@@ -90,6 +90,39 @@ export const consentServiceGetPrivacyNotices = async (req: Request) => {
 };
 
 /**
+ * use the /consents/:userId/:providerId/:consumerId/:contractId route of the consent manager
+ * @param req
+ */
+export const consentServiceGetPrivacyNoticesByContract = async (
+    req: Request
+) => {
+    try {
+        await getUserIdentifier(req);
+        const { userId, providerSd, consumerSd, contractSd } = req.params;
+
+        const response = await axios.get(
+            await verifyConsentUri(
+                `consents/${userId}/${providerSd}/${consumerSd}/${contractSd}`
+            ),
+            {
+                headers: {
+                    'x-user-key': userId,
+                },
+            }
+        );
+
+        return response.data;
+    } catch (e) {
+        Logger.error({
+            message: e.message,
+            location: e.stack,
+        });
+
+        throw e;
+    }
+};
+
+/**
  * use the /consents/:privacyNoticeId route of the consent manager
  * @param req
  */

--- a/src/routes/private/v1/consent.private.router.ts
+++ b/src/routes/private/v1/consent.private.router.ts
@@ -9,6 +9,7 @@ import {
     getUserConsentById,
     getUserPrivacyNoticeById,
     getUserPrivacyNotices,
+    getUserPrivacyNoticesByContract,
     giveConsent,
     revokeConsent,
 } from '../../../controllers/private/v1/consent.private.controller';
@@ -320,5 +321,46 @@ r.get('/participants/:userId/:id', auth, getUserConsentById);
  *         description: Successful response
  */
 r.get('/:userId/:providerSd/:consumerSd', auth, getUserPrivacyNotices);
+
+/**
+ * @swagger
+ * /private/consent/{userId}/{providerSd}/{consumerSd}/{contractSd}:
+ *   get:
+ *     summary: Get user privacy notices by contract
+ *     tags: [Consent]
+ *     security:
+ *       - jwt: []
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *        - name: contractSd
+ *          description: contract self-description in base64.
+ *          in: path
+ *          required: true
+ *          type: string
+ *        - name: providerSd
+ *          description: provider self-description in base64.
+ *          in: path
+ *          required: true
+ *          type: string
+ *        - name: consumerSd
+ *          description: consumer self-description in base64.
+ *          in: path
+ *          required: true
+ *          type: string
+ *        - name: userId
+ *          description: your internal id inside your app / database for the user.
+ *          in: path
+ *          required: true
+ *          type: string
+ *     responses:
+ *       '200':
+ *         description: Successful response
+ */
+r.get(
+    '/:userId/:providerSd/:consumerSd/:contractSd',
+    auth,
+    getUserPrivacyNoticesByContract
+);
 
 export default r;

--- a/src/routes/private/v1/user.private.router.ts
+++ b/src/routes/private/v1/user.private.router.ts
@@ -5,7 +5,9 @@ import {
     createUserToApp,
     deleteUser,
     excelImport,
+    getUserByEmail,
     getUserById,
+    getUserByUserId,
     getUsers,
     updateUser,
 } from '../../../controllers/private/v1/user.private.controller';
@@ -109,6 +111,50 @@ r.get('/', getUsers);
  *         description: Successful response
  */
 r.get('/:id', getUserById);
+
+/**
+ * @swagger
+ * /private/users/email/{email}:
+ *   get:
+ *     summary: Get a user by email
+ *     tags: [Users]
+ *     security:
+ *       - jwt: []
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *        - name: email
+ *          description: user email.
+ *          in: path
+ *          required: true
+ *          type: string
+ *     responses:
+ *       '200':
+ *         description: Successful response
+ */
+r.get('/email/:email', getUserByEmail);
+
+/**
+ * @swagger
+ * /private/users/userId/{userId}:
+ *   get:
+ *     summary: Get a user by userId/internalId
+ *     tags: [Users]
+ *     security:
+ *       - jwt: []
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *        - name: userId
+ *          description: user internal Id.
+ *          in: path
+ *          required: true
+ *          type: string
+ *     responses:
+ *       '200':
+ *         description: Successful response
+ */
+r.get('/userId/:userId', getUserByUserId);
 
 /**
  * @swagger

--- a/src/routes/public/v1/index.ts
+++ b/src/routes/public/v1/index.ts
@@ -43,7 +43,7 @@ const routers = [
         router: userPublicRouter,
     },
     {
-        prefix: '/node',
+        prefix: '/service-chain',
         router: nodePublicRouter,
     },
     {

--- a/src/routes/public/v1/node.public.router.ts
+++ b/src/routes/public/v1/node.public.router.ts
@@ -9,11 +9,11 @@ import {
 } from '../../../controllers/public/v1/node.public.controller';
 const r: Router = Router();
 
-r.post('/communicate/setup', setupNode);
-r.post('/communicate/run', runNode);
-r.post('/communicate/pause', pauseNode);
-r.post('/communicate/resume', resumeNode);
-r.post('/communicate/notify', notify);
-r.post('/communicate/pre', preProcess);
+r.post('/node/setup', setupNode);
+r.post('/node/run', runNode);
+r.post('/node/pause', pauseNode);
+r.post('/resume', resumeNode);
+r.post('/node/notify', notify);
+r.post('/node/pre', preProcess);
 
 export default r;

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,6 @@ import { globalErrorHandler } from './routes/middlewares/errorHandler.middleware
 import routes from './libs/loaders/routes';
 import {
     configurationSetUp,
-    getAppKey,
     getConfigFile,
     getExpressLimitSize,
     registerSelfDescription,
@@ -18,7 +17,6 @@ import { setup, serve } from 'swagger-ui-express';
 import { OpenAPIOption } from '../openapi-options';
 import path from 'path';
 import { writeFile } from 'fs';
-import { SupervisorContainer } from './libs/loaders/nodeSupervisor';
 
 export type AppServer = {
     app: express.Application;
@@ -46,14 +44,6 @@ export const startServer = async (port?: number) => {
     // Setup Swagger JSDoc
     const specs = swaggerJSDoc(OpenAPIOption);
 
-    writeFile(
-        path.join(__dirname, '../docs/swagger.json'),
-        JSON.stringify(specs, null, 2),
-        (err) => {
-            if (err)
-                Logger.error({ message: err.message, location: err.stack });
-        }
-    );
     app.use('/docs', serve, setup(specs));
 
     app.get('/health', (req: Request, res: Response) => {

--- a/src/services/public/v1/node.public.service.ts
+++ b/src/services/public/v1/node.public.service.ts
@@ -90,11 +90,17 @@ export const nodeCallbackService = async (props: {
         }
 
         if (pep) {
+            Logger.info({
+                message:
+                    'PEP is validated, processing of sending data to the remote service.',
+                location: 'nodeCallbackService',
+            });
             if (
                 (meta as CallbackMeta).configuration.signedConsent &&
                 (meta as CallbackMeta).configuration.encrypted
             ) {
-                const { signedConsent, encrypted } = (meta as CallbackMeta).configuration;
+                const { signedConsent, encrypted } = (meta as CallbackMeta)
+                    .configuration;
 
                 decryptedConsent = await decryptSignedConsent(
                     signedConsent,

--- a/src/utils/verifyInfrastructureInContract.ts
+++ b/src/utils/verifyInfrastructureInContract.ts
@@ -11,7 +11,11 @@ export const verifyInfrastructureInContract = (props: {
         (element) =>
             element.catalogId === chainId && element.status === 'active'
     );
-    if (!chain) return false;
+    if (!chain) {
+        throw Error(
+            `Chain with catalogId ${chainId} not found in the contract ${contract._id}. Chain is stopping here and not sending data to remote service.`
+        );
+    }
 
     const foundService = chain.services.find(
         (element: any) =>
@@ -22,6 +26,12 @@ export const verifyInfrastructureInContract = (props: {
                 )
             )
     );
+
+    if (!foundService) {
+        throw Error(
+            `Service ${service} not found in the chain ${chainId} from the contract ${contract._id}. Chain is stopping here and not sending data to remote service.`
+        );
+    }
 
     return !!foundService;
 };


### PR DESCRIPTION
## Features

- update dpcp library link
- version 1.9.0
- added proxy route to get privacy notice by contract
- added routes to get user by email or userId (internalId)
- added logs for PEP process in nodeCallback
- updated dpcp routes from `/node/communicate` to `/service-chain/node`
- deleted the autogeneration of the docs at each startup and replaced it by a new command `generate-swagger`