### PR TITLE
Implement KPI routes and corresponding tests

### DIFF
--- a/src/controllers/private/v1/kpi.private.controller.ts
+++ b/src/controllers/private/v1/kpi.private.controller.ts
@@ -1,0 +1,100 @@
+import { NextFunction, Request, Response } from 'express';
+import { restfulResponse } from '../../../libs/api/RESTfulResponse';
+import {
+    getKpiByOfferService,
+    getKpiOverviewService,
+    getKpiServiceChainService,
+    getKpiSimpleService,
+    getKpiVolumeService,
+} from '../../../services/private/v1/kpi.private.service';
+
+/**
+ * GET /private/kpis/exchanges/overview
+ * Returns global exchange KPIs: totals, success rate, bytes, simple vs service-chain breakdown.
+ */
+export const getKpiOverview = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+) => {
+    try {
+        const overview = await getKpiOverviewService();
+        return restfulResponse(res, 200, overview);
+    } catch (err) {
+        next(err);
+    }
+};
+
+/**
+ * GET /private/kpis/exchanges/by-offer
+ * Returns exchange count and success rate grouped by service offering URI.
+ * Query param: type=resource|purpose (default: resource)
+ */
+export const getKpiByOffer = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+) => {
+    try {
+        const type = req.query.type === 'purpose' ? 'purpose' : 'resource';
+        const byOffer = await getKpiByOfferService(type);
+        return restfulResponse(res, 200, byOffer);
+    } catch (err) {
+        next(err);
+    }
+};
+
+/**
+ * GET /private/kpis/exchanges/service-chain
+ * Returns total service-chain exchanges and their success rate.
+ */
+export const getKpiServiceChain = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+) => {
+    try {
+        const serviceChain = await getKpiServiceChainService();
+        return restfulResponse(res, 200, serviceChain);
+    } catch (err) {
+        next(err);
+    }
+};
+
+/**
+ * GET /private/kpis/exchanges/simple
+ * Returns total simple (bilateral) exchanges and their success rate.
+ */
+export const getKpiSimple = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+) => {
+    try {
+        const simple = await getKpiSimpleService();
+        return restfulResponse(res, 200, simple);
+    } catch (err) {
+        next(err);
+    }
+};
+
+/**
+ * GET /private/kpis/exchanges/volume
+ * Returns exchange volume over time (by day) and total bytes transferred.
+ * Query params: from (ISO date), to (ISO date) — both optional.
+ */
+export const getKpiVolume = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+) => {
+    try {
+        const from =
+            typeof req.query.from === 'string' ? req.query.from : undefined;
+        const to = typeof req.query.to === 'string' ? req.query.to : undefined;
+        const volume = await getKpiVolumeService(from, to);
+        return restfulResponse(res, 200, volume);
+    } catch (err) {
+        next(err);
+    }
+};

--- a/src/routes/private/v1/index.ts
+++ b/src/routes/private/v1/index.ts
@@ -5,6 +5,7 @@ import userPrivateRouter from './user.private.router';
 import consentPrivateRouter from './consent.private.router';
 import pdiPrivateRouter from './pdi.private.router';
 import infrastructureConfigurationPrivateRouter from './infrastructure.configuration.private.router';
+import kpiPrivateRouter from './kpi.private.router';
 
 /**
  * @swagger
@@ -47,6 +48,10 @@ const routers = [
     {
         prefix: '/infrastructure/configurations',
         router: infrastructureConfigurationPrivateRouter,
+    },
+    {
+        prefix: '/kpis',
+        router: kpiPrivateRouter,
     },
 ];
 

--- a/src/routes/private/v1/kpi.private.router.ts
+++ b/src/routes/private/v1/kpi.private.router.ts
@@ -1,0 +1,126 @@
+import { Router } from 'express';
+import {
+    getKpiByOffer,
+    getKpiOverview,
+    getKpiServiceChain,
+    getKpiSimple,
+    getKpiVolume,
+} from '../../../controllers/private/v1/kpi.private.controller';
+import { auth } from '../../middlewares/auth.middleware';
+
+const r: Router = Router();
+
+r.use(auth);
+
+/**
+ * @swagger
+ * tags:
+ *   name: KPIs
+ *   description: Exchange KPI metrics
+ */
+
+/**
+ * @swagger
+ * /private/kpis/exchanges/overview:
+ *   get:
+ *     summary: Global exchange KPI overview
+ *     tags: [KPIs]
+ *     security:
+ *       - jwt: []
+ *     produces:
+ *       - application/json
+ *     responses:
+ *       '200':
+ *         description: Successful response
+ */
+r.get('/exchanges/overview', getKpiOverview);
+
+/**
+ * @swagger
+ * /private/kpis/exchanges/by-offer:
+ *   get:
+ *     summary: Exchange count and success rate grouped by service offering
+ *     tags: [KPIs]
+ *     security:
+ *       - jwt: []
+ *     parameters:
+ *       - name: type
+ *         in: query
+ *         required: false
+ *         schema:
+ *           type: string
+ *           enum: [resource, purpose]
+ *           default: resource
+ *         description: Whether to group by provider resource offering or consumer purpose offering
+ *     produces:
+ *       - application/json
+ *     responses:
+ *       '200':
+ *         description: Successful response
+ */
+r.get('/exchanges/by-offer', getKpiByOffer);
+
+/**
+ * @swagger
+ * /private/kpis/exchanges/service-chain:
+ *   get:
+ *     summary: Service-chain exchange count and success rate
+ *     tags: [KPIs]
+ *     security:
+ *       - jwt: []
+ *     produces:
+ *       - application/json
+ *     responses:
+ *       '200':
+ *         description: Successful response
+ */
+r.get('/exchanges/service-chain', getKpiServiceChain);
+
+/**
+ * @swagger
+ * /private/kpis/exchanges/simple:
+ *   get:
+ *     summary: Simple (bilateral) exchange count and success rate
+ *     tags: [KPIs]
+ *     security:
+ *       - jwt: []
+ *     produces:
+ *       - application/json
+ *     responses:
+ *       '200':
+ *         description: Successful response
+ */
+r.get('/exchanges/simple', getKpiSimple);
+
+/**
+ * @swagger
+ * /private/kpis/exchanges/volume:
+ *   get:
+ *     summary: Exchange volume over time and total bytes transferred
+ *     tags: [KPIs]
+ *     security:
+ *       - jwt: []
+ *     parameters:
+ *       - name: from
+ *         in: query
+ *         required: false
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *         description: Start date (ISO 8601)
+ *       - name: to
+ *         in: query
+ *         required: false
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *         description: End date (ISO 8601)
+ *     produces:
+ *       - application/json
+ *     responses:
+ *       '200':
+ *         description: Successful response
+ */
+r.get('/exchanges/volume', getKpiVolume);
+
+export default r;

--- a/src/services/private/v1/kpi.private.service.ts
+++ b/src/services/private/v1/kpi.private.service.ts
@@ -1,0 +1,279 @@
+import { DataExchange } from '../../../utils/types/dataExchange';
+import { DataExchangeStatusEnum } from '../../../utils/enums/dataExchangeStatusEnum';
+
+const SUCCESS_STATUSES = [
+    DataExchangeStatusEnum.EXPORT_SUCCESS,
+    DataExchangeStatusEnum.IMPORT_SUCCESS,
+];
+
+export interface KpiOverview {
+    totalExchanges: number;
+    completedExchanges: number;
+    successfulExchanges: number;
+    globalSuccessRate: number;
+    totalBytesTransferred: number;
+    simpleExchanges: number;
+    serviceChainExchanges: number;
+}
+
+export interface KpiByOffer {
+    serviceOffering: string;
+    totalExchanges: number;
+    successfulExchanges: number;
+    successRate: number;
+}
+
+export interface KpiServiceChain {
+    totalServiceChainExchanges: number;
+    successfulServiceChainExchanges: number;
+    successRate: number;
+}
+
+export interface KpiSimple {
+    totalSimpleExchanges: number;
+    successfulSimpleExchanges: number;
+    successRate: number;
+}
+
+export interface KpiVolume {
+    totalBytesTransferred: number;
+    byteCoverageNote: string;
+    exchangesByDay: { date: string; count: number }[];
+}
+
+const BYTE_COVERAGE_NOTE =
+    'Only REST non-service-chain exchanges report a size. This total is partial.';
+
+const serviceChainFilter = { 'serviceChain.services.0': { $exists: true } };
+const simpleFilter = { 'serviceChain.services.0': { $exists: false } };
+
+export const getKpiOverviewService = async (): Promise<KpiOverview> => {
+    const [result] = await DataExchange.aggregate([
+        {
+            $facet: {
+                total: [{ $count: 'count' }],
+                completed: [
+                    {
+                        $match: {
+                            status: { $ne: DataExchangeStatusEnum.PENDING },
+                        },
+                    },
+                    { $count: 'count' },
+                ],
+                successful: [
+                    { $match: { status: { $in: SUCCESS_STATUSES } } },
+                    { $count: 'count' },
+                ],
+                bytes: [
+                    {
+                        $match: {
+                            'providerData.size': {
+                                $exists: true,
+                                $type: 'number',
+                            },
+                        },
+                    },
+                    {
+                        $group: {
+                            _id: null,
+                            total: { $sum: '$providerData.size' },
+                        },
+                    },
+                ],
+                serviceChain: [
+                    { $match: serviceChainFilter },
+                    { $count: 'count' },
+                ],
+                simple: [{ $match: simpleFilter }, { $count: 'count' }],
+            },
+        },
+    ]);
+
+    const totalExchanges: number = result.total[0]?.count ?? 0;
+    const completedExchanges: number = result.completed[0]?.count ?? 0;
+    const successfulExchanges: number = result.successful[0]?.count ?? 0;
+    const totalBytesTransferred: number = result.bytes[0]?.total ?? 0;
+    const serviceChainExchanges: number = result.serviceChain[0]?.count ?? 0;
+    const simpleExchanges: number = result.simple[0]?.count ?? 0;
+
+    return {
+        totalExchanges,
+        completedExchanges,
+        successfulExchanges,
+        globalSuccessRate:
+            totalExchanges > 0
+                ? Math.round((successfulExchanges / totalExchanges) * 1000) /
+                  1000
+                : 0,
+        totalBytesTransferred,
+        simpleExchanges,
+        serviceChainExchanges,
+    };
+};
+
+export const getKpiByOfferService = async (
+    type: 'resource' | 'purpose' = 'resource'
+): Promise<KpiByOffer[]> => {
+    const field =
+        type === 'purpose'
+            ? 'purposes.serviceOffering'
+            : 'resources.serviceOffering';
+
+    const arrayField = type === 'purpose' ? 'purposes' : 'resources';
+
+    const results = await DataExchange.aggregate([
+        { $unwind: `$${arrayField}` },
+        {
+            $match: {
+                [`${arrayField}.serviceOffering`]: { $exists: true, $ne: null },
+            },
+        },
+        {
+            $group: {
+                _id: `$${arrayField}.serviceOffering`,
+                totalExchanges: { $sum: 1 },
+                successfulExchanges: {
+                    $sum: {
+                        $cond: [{ $in: ['$status', SUCCESS_STATUSES] }, 1, 0],
+                    },
+                },
+            },
+        },
+        { $sort: { totalExchanges: -1 } },
+    ]);
+
+    return results.map((r) => ({
+        serviceOffering: r._id as string,
+        totalExchanges: r.totalExchanges as number,
+        successfulExchanges: r.successfulExchanges as number,
+        successRate:
+            r.totalExchanges > 0
+                ? Math.round(
+                      (r.successfulExchanges / r.totalExchanges) * 1000
+                  ) / 1000
+                : 0,
+    }));
+};
+
+export const getKpiServiceChainService = async (): Promise<KpiServiceChain> => {
+    const [result] = await DataExchange.aggregate([
+        { $match: serviceChainFilter },
+        {
+            $facet: {
+                total: [{ $count: 'count' }],
+                successful: [
+                    { $match: { status: { $in: SUCCESS_STATUSES } } },
+                    { $count: 'count' },
+                ],
+            },
+        },
+    ]);
+
+    const totalServiceChainExchanges: number = result.total[0]?.count ?? 0;
+    const successfulServiceChainExchanges: number =
+        result.successful[0]?.count ?? 0;
+
+    return {
+        totalServiceChainExchanges,
+        successfulServiceChainExchanges,
+        successRate:
+            totalServiceChainExchanges > 0
+                ? Math.round(
+                      (successfulServiceChainExchanges /
+                          totalServiceChainExchanges) *
+                          1000
+                  ) / 1000
+                : 0,
+    };
+};
+
+export const getKpiSimpleService = async (): Promise<KpiSimple> => {
+    const [result] = await DataExchange.aggregate([
+        { $match: simpleFilter },
+        {
+            $facet: {
+                total: [{ $count: 'count' }],
+                successful: [
+                    { $match: { status: { $in: SUCCESS_STATUSES } } },
+                    { $count: 'count' },
+                ],
+            },
+        },
+    ]);
+
+    const totalSimpleExchanges: number = result.total[0]?.count ?? 0;
+    const successfulSimpleExchanges: number = result.successful[0]?.count ?? 0;
+
+    return {
+        totalSimpleExchanges,
+        successfulSimpleExchanges,
+        successRate:
+            totalSimpleExchanges > 0
+                ? Math.round(
+                      (successfulSimpleExchanges / totalSimpleExchanges) * 1000
+                  ) / 1000
+                : 0,
+    };
+};
+
+export const getKpiVolumeService = async (
+    from?: string,
+    to?: string
+): Promise<KpiVolume> => {
+    const dateFilter: Record<string, Date> = {};
+    if (from) dateFilter.$gte = new Date(from);
+    if (to) dateFilter.$lte = new Date(to);
+
+    const timeMatch =
+        Object.keys(dateFilter).length > 0
+            ? { $match: { createdAt: dateFilter } }
+            : null;
+
+    const basePipeline = timeMatch ? [timeMatch] : [];
+
+    const [result] = await DataExchange.aggregate([
+        ...basePipeline,
+        {
+            $facet: {
+                bytes: [
+                    {
+                        $match: {
+                            'providerData.size': {
+                                $exists: true,
+                                $type: 'number',
+                            },
+                        },
+                    },
+                    {
+                        $group: {
+                            _id: null,
+                            total: { $sum: '$providerData.size' },
+                        },
+                    },
+                ],
+                byDay: [
+                    {
+                        $group: {
+                            _id: {
+                                $dateToString: {
+                                    format: '%Y-%m-%d',
+                                    date: '$createdAt',
+                                },
+                            },
+                            count: { $sum: 1 },
+                        },
+                    },
+                    { $sort: { _id: 1 } },
+                ],
+            },
+        },
+    ]);
+
+    return {
+        totalBytesTransferred: result.bytes[0]?.total ?? 0,
+        byteCoverageNote: BYTE_COVERAGE_NOTE,
+        exchangesByDay: (result.byDay as { _id: string; count: number }[]).map(
+            (d) => ({ date: d._id, count: d.count })
+        ),
+    };
+};

--- a/src/tests/services/kpi.private.service.spec.ts
+++ b/src/tests/services/kpi.private.service.spec.ts
@@ -1,0 +1,221 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { DataExchange } from '../../utils/types/dataExchange';
+import {
+    getKpiOverviewService,
+    getKpiByOfferService,
+    getKpiServiceChainService,
+    getKpiSimpleService,
+    getKpiVolumeService,
+} from '../../services/private/v1/kpi.private.service';
+
+describe('KPI Private Service', () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe('getKpiOverviewService', () => {
+        it('should return correct overview when there are exchanges', async () => {
+            sinon.stub(DataExchange, 'aggregate').resolves([
+                {
+                    total: [{ count: 10 }],
+                    completed: [{ count: 8 }],
+                    successful: [{ count: 6 }],
+                    bytes: [{ total: 2048 }],
+                    serviceChain: [{ count: 3 }],
+                    simple: [{ count: 7 }],
+                },
+            ]);
+
+            const result = await getKpiOverviewService();
+
+            expect(result.totalExchanges).to.equal(10);
+            expect(result.completedExchanges).to.equal(8);
+            expect(result.successfulExchanges).to.equal(6);
+            expect(result.globalSuccessRate).to.equal(0.6);
+            expect(result.totalBytesTransferred).to.equal(2048);
+            expect(result.serviceChainExchanges).to.equal(3);
+            expect(result.simpleExchanges).to.equal(7);
+        });
+
+        it('should return zero success rate when totalExchanges is 0', async () => {
+            sinon.stub(DataExchange, 'aggregate').resolves([
+                {
+                    total: [],
+                    completed: [],
+                    successful: [],
+                    bytes: [],
+                    serviceChain: [],
+                    simple: [],
+                },
+            ]);
+
+            const result = await getKpiOverviewService();
+
+            expect(result.totalExchanges).to.equal(0);
+            expect(result.globalSuccessRate).to.equal(0);
+            expect(result.totalBytesTransferred).to.equal(0);
+        });
+    });
+
+    describe('getKpiByOfferService', () => {
+        it('should return KPIs grouped by resource offering', async () => {
+            sinon.stub(DataExchange, 'aggregate').resolves([
+                {
+                    _id: 'https://catalog.api.com/serviceofferings/abc',
+                    totalExchanges: 5,
+                    successfulExchanges: 4,
+                },
+                {
+                    _id: 'https://catalog.api.com/serviceofferings/xyz',
+                    totalExchanges: 2,
+                    successfulExchanges: 1,
+                },
+            ]);
+
+            const result = await getKpiByOfferService('resource');
+
+            expect(result).to.have.length(2);
+            expect(result[0].serviceOffering).to.equal(
+                'https://catalog.api.com/serviceofferings/abc'
+            );
+            expect(result[0].successRate).to.equal(0.8);
+            expect(result[1].successRate).to.equal(0.5);
+        });
+
+        it('should return an empty array when no exchanges exist', async () => {
+            sinon.stub(DataExchange, 'aggregate').resolves([]);
+
+            const result = await getKpiByOfferService();
+
+            expect(result).to.deep.equal([]);
+        });
+
+        it('should return 0 successRate when totalExchanges is 0', async () => {
+            sinon.stub(DataExchange, 'aggregate').resolves([
+                {
+                    _id: 'https://catalog.api.com/serviceofferings/abc',
+                    totalExchanges: 0,
+                    successfulExchanges: 0,
+                },
+            ]);
+
+            const result = await getKpiByOfferService();
+
+            expect(result[0].successRate).to.equal(0);
+        });
+    });
+
+    describe('getKpiServiceChainService', () => {
+        it('should return service chain KPIs', async () => {
+            sinon.stub(DataExchange, 'aggregate').resolves([
+                {
+                    total: [{ count: 12 }],
+                    successful: [{ count: 9 }],
+                },
+            ]);
+
+            const result = await getKpiServiceChainService();
+
+            expect(result.totalServiceChainExchanges).to.equal(12);
+            expect(result.successfulServiceChainExchanges).to.equal(9);
+            expect(result.successRate).to.equal(0.75);
+        });
+
+        it('should return 0 successRate when no service chain exchanges exist', async () => {
+            sinon.stub(DataExchange, 'aggregate').resolves([
+                {
+                    total: [],
+                    successful: [],
+                },
+            ]);
+
+            const result = await getKpiServiceChainService();
+
+            expect(result.totalServiceChainExchanges).to.equal(0);
+            expect(result.successRate).to.equal(0);
+        });
+    });
+
+    describe('getKpiSimpleService', () => {
+        it('should return simple exchange KPIs', async () => {
+            sinon.stub(DataExchange, 'aggregate').resolves([
+                {
+                    total: [{ count: 20 }],
+                    successful: [{ count: 15 }],
+                },
+            ]);
+
+            const result = await getKpiSimpleService();
+
+            expect(result.totalSimpleExchanges).to.equal(20);
+            expect(result.successfulSimpleExchanges).to.equal(15);
+            expect(result.successRate).to.equal(0.75);
+        });
+
+        it('should return 0 successRate when no simple exchanges exist', async () => {
+            sinon.stub(DataExchange, 'aggregate').resolves([
+                {
+                    total: [],
+                    successful: [],
+                },
+            ]);
+
+            const result = await getKpiSimpleService();
+
+            expect(result.totalSimpleExchanges).to.equal(0);
+            expect(result.successRate).to.equal(0);
+        });
+    });
+
+    describe('getKpiVolumeService', () => {
+        it('should return volume data with day breakdown', async () => {
+            sinon.stub(DataExchange, 'aggregate').resolves([
+                {
+                    bytes: [{ total: 4096 }],
+                    byDay: [
+                        { _id: '2026-03-01', count: 5 },
+                        { _id: '2026-03-02', count: 3 },
+                    ],
+                },
+            ]);
+
+            const result = await getKpiVolumeService();
+
+            expect(result.totalBytesTransferred).to.equal(4096);
+            expect(result.exchangesByDay).to.deep.equal([
+                { date: '2026-03-01', count: 5 },
+                { date: '2026-03-02', count: 3 },
+            ]);
+            expect(result.byteCoverageNote).to.be.a('string');
+        });
+
+        it('should return 0 bytes and empty day array when no data', async () => {
+            sinon.stub(DataExchange, 'aggregate').resolves([
+                {
+                    bytes: [],
+                    byDay: [],
+                },
+            ]);
+
+            const result = await getKpiVolumeService();
+
+            expect(result.totalBytesTransferred).to.equal(0);
+            expect(result.exchangesByDay).to.deep.equal([]);
+        });
+
+        it('should pass date filters to the aggregation pipeline', async () => {
+            const aggregateStub = sinon
+                .stub(DataExchange, 'aggregate')
+                .resolves([{ bytes: [], byDay: [] }]);
+
+            await getKpiVolumeService('2026-01-01', '2026-03-31');
+
+            const pipeline = aggregateStub.firstCall.args[0] as Record<string, any>[];
+            const matchStage = pipeline[0]['$match'];
+            expect(matchStage).to.have.property('createdAt');
+            expect(matchStage.createdAt.$gte).to.be.instanceOf(Date);
+            expect(matchStage.createdAt.$lte).to.be.instanceOf(Date);
+        });
+    });
+});


### PR DESCRIPTION
This pull request introduces a new set of backend endpoints and supporting logic for retrieving exchange KPI (Key Performance Indicator) metrics, along with comprehensive unit tests to ensure correctness. The changes add controllers, service methods, routes, and documentation for various KPI aggregations, enabling secure access to metrics such as overall exchange statistics, breakdowns by offer, and volume over time.

The most important changes are:

**KPI Service Layer Implementation:**
* Added `kpi.private.service.ts` with service functions to aggregate and return KPI metrics (overview, by offer, service-chain, simple, and volume) from `DataExchange` records, including logic for success rates, byte counts, and date filtering.

**Controller and Routing:**
* Introduced `kpi.private.controller.ts` with controller functions for each KPI endpoint, handling requests, invoking service logic, and formatting responses.
* Added `kpi.private.router.ts` to define and document five new `/private/kpis/exchanges/...` endpoints, each protected by authentication middleware and described with Swagger annotations.
* Registered the new KPI router in the main private v1 route index and mounted it under the `/kpis` prefix. [[1]](diffhunk://#diff-938004588f9771b99052310788e8e36966062c8eec2b32612c03cf7bdf600a3cR8) [[2]](diffhunk://#diff-938004588f9771b99052310788e8e36966062c8eec2b32612c03cf7bdf600a3cR52-R55)

**Testing:**
* Added `kpi.private.service.spec.ts` with unit tests for all service functions, using stubs to simulate database aggregation and verifying correct calculation and handling of edge cases.